### PR TITLE
Allow writable Element constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # domino x.x.x (not yet released)
+* Allow writable Element constructors if __domin_frozen is set to false (#138)
 * Bug fix for CSS `$=` selector. (#135)
 
 # domino 2.1.1 (30 Nov 2018)

--- a/lib/defineElement.js
+++ b/lib/defineElement.js
@@ -2,6 +2,7 @@
 
 var attributes = require('./attributes');
 var sloppy = require('./sloppy');
+var isApiWritable = require("./config").isApiWritable;
 
 module.exports = function(spec, defaultConstructor, tagList, tagNameToImpl) {
   var c = spec.ctor;
@@ -17,7 +18,7 @@ module.exports = function(spec, defaultConstructor, tagList, tagNameToImpl) {
       }
     }
 
-    props.constructor = { value : c };
+    props.constructor = { value : c, writable: isApiWritable };
     c.prototype = Object.create((spec.superclass || defaultConstructor).prototype, props);
     if (spec.events) {
       addEventHandlers(c, spec.events);


### PR DESCRIPTION
If __domino_frozen__ is set to 'false' allow *Element constructors to be writable.

This is needed to support Custom Element polyfill on Domino when used by Angular on the server.

This fixes https://github.com/angular/angular/issues/27732.